### PR TITLE
fix: duplicate block name "additional"

### DIFF
--- a/Block/Set/View.php
+++ b/Block/Set/View.php
@@ -38,7 +38,7 @@ class View extends SmileCustomEntityView
      */
     public function getAdditionalHtml()
     {
-        return $this->getChildHtml('additional');
+        return $this->getChildHtml('set_additional');
     }
 
     /**

--- a/view/frontend/layout/smile_custom_entity_set_view.xml
+++ b/view/frontend/layout/smile_custom_entity_set_view.xml
@@ -19,7 +19,7 @@
     <body>
         <referenceBlock name="smile_custom_entity_list_pager" remove="true" />
         <referenceBlock name="smile_custom_entity_set_view" template="Amadeco_SmileCustomEntityLayeredNavigation::set/view.phtml">
-            <container name="custom.entity.additional" as="additional" />
+            <container name="custom.entity.set.additional" as="set_additional" />
             <block class="Amadeco\SmileCustomEntityLayeredNavigation\Block\SetList" name="set.list" as="set_list" template="Amadeco_SmileCustomEntityLayeredNavigation::set/list.phtml" after="custom.entity.additional">
                 <container name="set.list.additional" as="additional" />
                 <block class="Amadeco\SmileCustomEntityLayeredNavigation\Block\SetList\Toolbar" name="set_list_toolbar" template="Amadeco_SmileCustomEntityLayeredNavigation::set/list/toolbar.phtml">


### PR DESCRIPTION
Solve exception 

> The element "smile_custom_entity_set_view" can't have a child because "smile_custom_entity_set_view" already has a child with alias "additional".