### PR TITLE
 fix(plugin): prevent undefined method error in MetaRobotsPlugin by adding instance check

### DIFF
--- a/Plugin/MetaRobotsPlugin.php
+++ b/Plugin/MetaRobotsPlugin.php
@@ -9,36 +9,39 @@
  *
  * @category  Amadeco
  * @package   Amadeco_SmileCustomEntityLayeredNavigation
- * @copyright Copyright (c) Amadeco (https://www.amadeco.fr) - Ilan Parmentier
+ * @copyright Copyright (c) Amadeco[](https://www.amadeco.fr) - Ilan Parmentier
  * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
  */
 declare(strict_types=1);
 
 namespace Amadeco\SmileCustomEntityLayeredNavigation\Plugin;
 
-use Smile\CustomEntity\Controller\Set\View;
 use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\ResultInterface;
 use Magento\Framework\View\Page\Config as PageConfig;
 use Magento\Framework\View\Result\Page;
+use Smile\CustomEntity\Controller\Set\View;
 
 /**
- * Plugin to set NOINDEX,FOLLOW meta robots on filtered pages
+ * Plugin to set NOINDEX,FOLLOW meta robots on filtered custom entity pages.
  */
 class MetaRobotsPlugin
 {
     /**
      * @var RequestInterface
      */
-    private RequestInterface $request;
+    private readonly RequestInterface $request;
 
     /**
      * @var PageConfig
      */
-    private PageConfig $pageConfig;
+    private readonly PageConfig $pageConfig;
 
     /**
-     * @param RequestInterface $request
-     * @param PageConfig $pageConfig
+     * Constructor.
+     *
+     * @param RequestInterface $request    The HTTP request object.
+     * @param PageConfig       $pageConfig The page configuration object.
      */
     public function __construct(
         RequestInterface $request,
@@ -49,14 +52,14 @@ class MetaRobotsPlugin
     }
 
     /**
-     * Execute
+     * Sets meta robots to NOINDEX,FOLLOW if filters are applied on custom entity pages.
      *
-     * @param View $subject
-     * @param Page $page
+     * @param View            $subject    The original controller action.
+     * @param ResultInterface $resultPage The result from the controller execution.
      *
-     * @return mixed
+     * @return ResultInterface The modified or original result page.
      */
-    public function afterExecute(View $subject, $resultPage)
+    public function afterExecute(View $subject, ResultInterface $resultPage): ResultInterface
     {
         if (!$this->isCustomEntityPage()) {
             return $resultPage;
@@ -70,33 +73,41 @@ class MetaRobotsPlugin
     }
 
     /**
-     * Check if current page is a custom entity page
+     * Checks if the current page is a custom entity page.
      *
-     * @return bool
+     * @return bool True if it's a custom entity page, false otherwise.
      */
     private function isCustomEntityPage(): bool
     {
         $moduleName = $this->request->getModuleName();
         $controllerName = $this->request->getControllerName();
+
         return $moduleName === 'custom_entity' && $controllerName === 'set';
     }
-    
+
     /**
-     * Check if filters are applied to the current page
+     * Checks if filters are applied to the current page.
      *
-     * @param ResultInterface $resultPage
-     * @return bool
+     * @param ResultInterface $resultPage The controller result object.
+     *
+     * @return bool True if filters are applied, false otherwise.
      */
-    private function hasAppliedFilters($resultPage): bool
+    private function hasAppliedFilters(ResultInterface $resultPage): bool
     {
+        if (!$resultPage instanceof Page) {
+            return false;
+        }
+
         $layout = $resultPage->getLayout();
         if (!$layout) {
             return false;
         }
+
         $state = $layout->getBlock('set.layer.state');
         if ($state && $state->getActiveFilters()) {
             return true;
         }
+
         return false;
     }
 }


### PR DESCRIPTION
fix(plugin): prevent undefined method error in MetaRobotsPlugin by adding instance check

**Description:**

- Added a check in `hasAppliedFilters()` to ensure `$resultPage` is an instance of `Magento\Framework\View\Result\Page` before accessing layout methods. This resolves the critical error where `getLayout()` was called on incompatible result types like `Forward`.
- Updated PHPDoc comments and code structure for better clarity and maintainability.
- Ensured compatibility with Magento 2.4.8 and PHP 8.3 standards.