### PR TITLE
fix: restore full EAV attribute loading in layered navigation collection

### DIFF
--- a/Model/Layer/CollectionFilter.php
+++ b/Model/Layer/CollectionFilter.php
@@ -32,13 +32,6 @@ class CollectionFilter implements CollectionFilterInterface
         $collection,
         AttributeSetInterface $entity
     ) {
-        $collection->addAttributeToSelect(
-            [
-                'name',
-                'image',
-                'url_key',
-                'attribute_set_id'
-            ]
-        );
+        $collection->addAttributeToSelect('*');
     }
 }

--- a/Model/Layer/CollectionFilter.php
+++ b/Model/Layer/CollectionFilter.php
@@ -21,12 +21,19 @@ use Amadeco\SmileCustomEntityLayeredNavigation\Model\Layer\CollectionFilterInter
 
 class CollectionFilter implements CollectionFilterInterface
 {
-    /**
-     * Filter entity collection
-     *
+    /**                                                                                                                         
+     * Filter entity collection                                                                                                 
+     *                                                                                                                          
+     * Loads all EAV attributes via addAttributeToSelect('*') to match the behavior of                                          
+     * CustomEntityRepository::getList(), which is the standard loading path used by entity                                     
+     * sets without filterable attributes. A previous hardcoded whitelist of 4 attributes                                       
+     * caused any custom attribute (e.g. resume, description) to be silently absent from                                        
+     * templates when the layered navigation path was active. Selecting '*' ensures parity                                      
+     * regardless of which attributes exist now or are added in the future.
+     *                                                                                                                          
      * @param $collection
      * @param AttributeSetInterface $entity
-     * @return void
+     * @return void                                                                                                             
      */
     public function filter(
         $collection,


### PR DESCRIPTION
##  Problem                                                                                                                     
   
  Custom entity attributes added after initial module setup (e.g. _resume_) were silently absent on entity set listing pages    
  that go through the layered navigation path — any _Smile_CustomEntity_ attribute set with at least one filterable attribute.
                                                                                                                              
###   Root cause

  `Amadeco\SmileCustomEntityLayeredNavigation\Model\Layer\CollectionFilter::filter()` builds the entity collection with a       
  hardcoded 4-attribute whitelist:
                                                                                                                              
`  $collection->addAttributeToSelect(['name', 'image', 'url_key', 'attribute_set_id']);`
                                                                                                                              
  This diverges from `Smile\CustomEntity\Model\CustomEntityRepository::getList()` — the standard loading path used by sets      
  without filterable attributes (e.g. _Material_, _Brand_) — which loads everything:                                              
                                                                                                                              
`  $collection->addAttributeToSelect('*');`

  When the layered navigation kicks in (ViewPlugin adds the type_layered layout handle because filterable attributes exist),  
  ItemCollectionProvider creates its own collection and CollectionFilter applies only the whitelist. Any EAV attribute outside
   those 4 is never joined, so `getResume()`, `getDescription()`, or any future custom attribute returns null in templates —      
  silently, with no error.

###   Why it was hard to diagnose                                                                                                 
   
  Three misleading signals delayed finding the root cause:                                                                    
           
  1. **Data existed in the database.** smile_custom_entity_text had 384 rows for attribute_id = 463 (resume), which looked        
  correct.
  2. **NULL-value rows created a false positive.** Many of those 384 rows had value = NULL — rows created when entities were saved
   with an empty field. Checking t.entity_id IS NOT NULL counted them as "has resume", when in reality only ~70 Collection    
  entities had actual content.
  3. **Material worked, Collection didn't.** Material has no filterable attributes → standard repository path →                   
  addAttributeToSelect('*') → works. Collection has filterable attributes → layered nav path → whitelist → broken. The        
  inconsistency pointed to the routing split, not the data.
                                                                                                                              
###   Fix      

```
  // CollectionFilter.php

  // Before — hardcoded whitelist, breaks for any attribute outside the 4                                                     
  $collection->addAttributeToSelect(['name', 'image', 'url_key', 'attribute_set_id']);
                                                                                                                              
  // After — matches CustomEntityRepository::getList() behavior exactly
  $collection->addAttributeToSelect('*');
```

  This restores parity with Smile's own repository. The layered navigation module was introducing a regression relative to the
   standard path — not an intentional optimization.
                                                                                                                              
###   On performance

  `addAttributeToSelect('*')` runs one SQL JOIN per EAV backend type table (_varchar, _text, _int, _datetime, _decimal) against 
  the already-paginated entity set — typically 20 items per page. This is identical to what `CustomEntityRepository::getList()`
  has always done for non-layered sets. Smile made this tradeoff deliberately; our module should respect it.                  
           
  If a specific high-traffic set requires restricting attribute loading in the future, the correct mechanism is to inject a   
  configurable attribute list into CollectionFilter via di.xml or add an attributes_to_select layout XML argument on the
  SetList block — both additive, without touching this class again.                                                           
           
###   Impact

  - Entity sets with filterable attributes (layered nav) now load the full EAV attribute payload, matching sets without       
  filterable attributes
  - No schema or data changes                                                                                                 
  - No reindex required
  - Cache flush required after deploy (bin/magento cache:flush)
                                                                                                                              
###   Testing
                                                                                                                              
  1. Open a listing page for an entity set with filterable attributes (e.g. /collection)                                      
  2. Confirm custom attributes (e.g. _resume_) render in item templates
  3. Open a listing page for a set without filterable attributes (e.g. /material) — verify no regression                      
  4. Apply an active filter and confirm filtered results also carry the attribute values    